### PR TITLE
Support .browserslistrc

### DIFF
--- a/src/rules/compat.ts
+++ b/src/rules/compat.ts
@@ -203,13 +203,12 @@ export default ESLintUtils.RuleCreator((name) => "")<Options, keyof typeof messa
     },
     defaultOptions: [
         {
-            browserslist: "defaults",
             polyfills: []
         }
     ],
     create(context, [options]) {
         const browserslistConfig =
-            (context.settings.browserslist as undefined | string | string[]) ?? options.browserslist ?? "defaults";
+            (context.settings.browserslist as undefined | string | string[]) ?? options.browserslist;
         const targetBrowsersList = browserslist(browserslistConfig, { path: context.getFilename() });
         const ignorePolyfillSet = createPolyfillSets(
             (context.settings.polyfills as undefined | string[]) ?? options.polyfills ?? options

--- a/src/rules/compat.ts
+++ b/src/rules/compat.ts
@@ -156,7 +156,7 @@ const createPolyfillSets = (polyfills: string[]) => {
 };
 export type Options = [
     {
-        browserslist: string | string[];
+        browserslist?: string | string[];
         polyfills: string[];
     }
 ];


### PR DESCRIPTION
### Steps to reproduce

1. Add a `.browserslistrc` file to your project:

    ```
    ie 11
    ```

2. Add a TS file to your project that uses features not available in IE11:

    ```ts
    const a = [1, 2, 3];
    a.includes(2);
    ```

3. Configure eslint with `eslint-plugin-typescript-compat`. Notice that the `browserslist` setting is not defined: 

    ```js
    {
        "extends": ["plugin:typescript-compat/recommended"],
        "env": {
          "browser": true
        },
        "parserOptions": {
          "project": "./tsconfig.json"
        }
    }
    ```

4. Run eslint and see that it doesn't show an error that `Array.prototype.includes()` is not supported in IE11.

### Problem

The problem is that when there is no browserslist defined in .eslintrc like in the above example, then `eslint-plugin-typescript-compat` uses the value `"defaults"`, instead of reading a `.browserslistrc` file.

### Solution

Don't set a default browserslist value. This makes the `browserslist` library automatically read a `.browserslistrc` file. If `.browserslistrc` doesn't exist, then `browserslist` will automatically use `"defaults"`. It doesn't need to be passed by eslint-plugin-typescript-compat. 

